### PR TITLE
[ci skip] Get more Open Source Helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Tatakai
 [![CodeFactor](https://www.codefactor.io/repository/github/calexil/tatakai/badge)](https://www.codefactor.io/repository/github/calexil/tatakai)
+[![Help Contribute to Open Source](https://www.codetriage.com/calexil/tatakai/badges/users.svg)](https://www.codetriage.com/calexil/tatakai)
+
 ## Story
 Gathered on the world stage for the first time ever, the greatest martial arts masters in the world compete for the title of "Combat Master"
 
@@ -10,70 +12,70 @@ Instead of continuing on with violent and repulsive wars, the "Combat Master Tou
 ## Combat Master(Main Story)
 
 ### Characters
-Chiharu (JP)  
+Chiharu (JP)
 Ninja, Ninjitsu
 
-Isabel (BR)  
+Isabel (BR)
 Capioera
 
-Lily (UK/GB)  
+Lily (UK/GB)
 Stylized Karate
 
-Sarah(USA)  
+Sarah(USA)
 Wrestler/Grappler
 
-Xiaoli(CN)  
+Xiaoli(CN)
 Tai Chi / Kung fu
 
-Bruno(BR)  
-Freeform, Electricity 
+Bruno(BR)
+Freeform, Electricity
 
-JD(USA)  
+JD(USA)
 Brawler
 
-Kohaku(JP)  
+Kohaku(JP)
 Samurai
 
-Lao(CN)  
+Lao(CN)
 Jeet kune do
 
-Miguel(ES)  
+Miguel(ES)
 Rapier
 
 ### Normals
-lp - Light Punch, A fast but weak standing normal, safe on block except air  
-mp - Medium Punch, Medium speed medium power, not safe on block for most characters, air safe(Priority)  
-hp - Heavy Punch, Slow moving high damage punch, dp cannot be parried  
+lp - Light Punch, A fast but weak standing normal, safe on block except air
+mp - Medium Punch, Medium speed medium power, not safe on block for most characters, air safe(Priority)
+hp - Heavy Punch, Slow moving high damage punch, dp cannot be parried
 
-lk - Light Kick, A fast but weak standing normal, safe on block except overheads  
-mk - Medium Kick, Mid speed startup, multi hit in some cases, safe on block rarely  
-hk - Heavy Kick, Slow startup high damage kick, can be overhead on some characters  
+lk - Light Kick, A fast but weak standing normal, safe on block except overheads
+mk - Medium Kick, Mid speed startup, multi hit in some cases, safe on block rarely
+hk - Heavy Kick, Slow startup high damage kick, can be overhead on some characters
 
-grb - Grab, you grab your opponent, directional, can be parried or grab countered, parry adds stun, air okay  
-cgrb - Command Grab, Uncounterable Grab, slow startup, higher damage and knockdown upon success  
+grb - Grab, you grab your opponent, directional, can be parried or grab countered, parry adds stun, air okay
+cgrb - Command Grab, Uncounterable Grab, slow startup, higher damage and knockdown upon success
 
-blk - Block, Block your opponent, Directional(Stand/Crouch/Air)  
-pblk - PushBlock, While in block stun(blocking hits) hit p+p or k+k  
+blk - Block, Block your opponent, Directional(Stand/Crouch/Air)
+pblk - PushBlock, While in block stun(blocking hits) hit p+p or k+k
 
-jmp - Jump, Press up, Directional  
-sjmp - Super Jump, press down up, directional  
-dbljmp - Double Jump, press up a second time in the air, directional  
+jmp - Jump, Press up, Directional
+sjmp - Super Jump, press down up, directional
+dbljmp - Double Jump, press up a second time in the air, directional
 
-dash - Dash, tap forward or back or lp+mp  
-adash - Air Dash, Dash in the air, tap forward or back or lp+mp/back lp+mp  
+dash - Dash, tap forward or back or lp+mp
+adash - Air Dash, Dash in the air, tap forward or back or lp+mp/back lp+mp
 
-parry - Parry, press towards your opponent to counter their move, multi-hit okay, air okay, super okay, cannot stop command grab  
+parry - Parry, press towards your opponent to counter their move, multi-hit okay, air okay, super okay, cannot stop command grab
 yes... we have parries!!
 
 ### Specials
-Chiharu  
-Isabel  
-Lily  
-Sarah  
-Xiaoli  
+Chiharu
+Isabel
+Lily
+Sarah
+Xiaoli
 
-Bruno  
-JD  
-Kohaku  
-Lee  
-Miguel  
+Bruno
+JD
+Kohaku
+Lee
+Miguel


### PR DESCRIPTION
[CodeTriage](https://www.codetriage.com/) is an app I have maintained
for the past 4-5 years with the goal of getting people involved in
Open Source projects like this one. The app sends subscribers a random
open issue for them to help "triage". For some languages you can also
suggested areas to add documentation.

The initial approach was inspired by seeing the work of the small
core team spending countless hours asking "what version was
this in" and "can you give us an example app". The idea is to
outsource these small interactions to a huge team of volunteers
and let the core team focus on their work.

I want to add a badge to the README of this project. The idea is to
provide an easy link for people to get started contributing to this
project. A badge indicates the number of people currently subscribed
to help the repo. The color is based off of open issues in the project.

Here are some examples of other projects that have a badge in their
README:

- https://github.com/crystal-lang/crystal
- https://github.com/rails/rails
- https://github.com/codetriage/codetriage

Thanks for building open source software, I would love to help you find some helpers.